### PR TITLE
Use coverage network 8545

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -40,4 +40,4 @@ jobs:
       - run: yarn solhint
       - run: yarn lint
       - run: yarn test
-      - run: yarn coveralls
+      - run: yarn coverage --network coverage

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -36,6 +36,11 @@ module.exports = {
    */
 
   networks: {
+    coverage: {
+      host: '127.0.0.1',
+      port: 8545,
+      network_id: '*'
+    }
     // Useful for testing. The `development` name is special - truffle uses it by default
     // if it's defined here and no other network is specified at the command line.
     // You should run a client (like ganache-cli, geth or parity) in a separate terminal


### PR DESCRIPTION
Something's wrong with Truffle. It's automatically launching its own client on 8545 and trying to communicate with it in the background. 

The reasons tests passed for me locally is that I had a client running on that port already. 

A workaround seems to be specifying that coverage run on 8545.  

